### PR TITLE
Bugfix/base bullet generalization

### DIFF
--- a/Assets/Prefabs/Guns/MangoLauncher.prefab
+++ b/Assets/Prefabs/Guns/MangoLauncher.prefab
@@ -161,7 +161,7 @@ MonoBehaviour:
   pointFireSpreadMOA: 1
   adsSpreadMOA: 0.1
   pelletSpreadMOA: 2
-  recoilY: 0
+  recoilY: 2.3
   recoilX: 0
   Optics: 2
   meleeDamage: 10

--- a/Assets/Prefabs/Guns/MangoLauncher.prefab
+++ b/Assets/Prefabs/Guns/MangoLauncher.prefab
@@ -92,6 +92,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -130,7 +133,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gunName: Mango Launcher
-  ammoType: {fileID: 6661516185590720827, guid: c028ae1e7150b0f4d8e758263bd236e7, type: 3}
+  ammoPrefab: {fileID: 7218848645403415054, guid: 0177191dbab71c743828e77d21bf8516, type: 3}
   ammoCapacity: 20
   mass: 0.1
   muzzleVelocity: 52
@@ -142,7 +145,7 @@ MonoBehaviour:
   chargingTime: 0.5
   defaultFireMode: 1
   maxDamage: 1
-  minDamage: 1
+  minDamage: 0
   maxDamageRange: 10
   minDamageRange: 100
   armorPenetrationPercent: 0
@@ -158,7 +161,7 @@ MonoBehaviour:
   pointFireSpreadMOA: 1
   adsSpreadMOA: 0.1
   pelletSpreadMOA: 2
-  recoilY: 5
+  recoilY: 0
   recoilX: 0
   Optics: 2
   meleeDamage: 10

--- a/Assets/Prefabs/Projectiles/BulletLite_01.prefab
+++ b/Assets/Prefabs/Projectiles/BulletLite_01.prefab
@@ -26,12 +26,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1402584404299819034}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.0124555975, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4239277815306136001}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6988364918651726719
 MeshFilter:
@@ -52,11 +53,15 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 257
   m_RendererPriority: 0
   m_Materials:
@@ -90,9 +95,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1402584404299819034}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: -2862770905735805310, guid: eb6fb30532e4f0a4b8a2278f7dae041d, type: 3}
@@ -122,12 +135,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1925061754148376579}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4239277815306136001}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1458599376233093412
 MeshFilter:
@@ -148,11 +162,15 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 257
   m_RendererPriority: 0
   m_Materials:
@@ -186,9 +204,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1925061754148376579}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 3477551807173390131, guid: eb6fb30532e4f0a4b8a2278f7dae041d, type: 3}
@@ -201,6 +227,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4239277815306136001}
+  - component: {fileID: -2485356339244439077}
   m_Layer: 0
   m_Name: BulletLite_01
   m_TagString: Untagged
@@ -215,12 +242,31 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3575611928538805115}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5301320226799411071}
   - {fileID: 4603650724454726173}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-2485356339244439077
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3575611928538805115}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 963ec64d2cc145740b2d676b58cbc478, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hit: 0
+  hitObject: {fileID: 0}
+  source: {fileID: 0}
+  despawnTime: 5
+  despawnOnCollisionTime: 0.1
+  stopAfterCollision: 1

--- a/Assets/Prefabs/Projectiles/BulletLite_02.prefab
+++ b/Assets/Prefabs/Projectiles/BulletLite_02.prefab
@@ -26,12 +26,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4309417470527926769}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.025456797, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4713719514245437058}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4412410245660647037
 MeshFilter:
@@ -52,11 +53,15 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 257
   m_RendererPriority: 0
   m_Materials:
@@ -90,9 +95,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4309417470527926769}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 1985688775922735085, guid: 845a646869bbb9449b4bb2c5973d6dc7, type: 3}
@@ -105,6 +118,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4713719514245437058}
+  - component: {fileID: 3104548109529203547}
+  - component: {fileID: -2821315963435612542}
+  - component: {fileID: -3140707969141230617}
   m_Layer: 0
   m_Name: BulletLite_02
   m_TagString: Untagged
@@ -119,15 +135,82 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5341742223406746680}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5870464556724626218}
   - {fileID: 7031907993768011620}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3104548109529203547
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5341742223406746680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 963ec64d2cc145740b2d676b58cbc478, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hit: 0
+  hitObject: {fileID: 0}
+  source: {fileID: 0}
+  despawnTime: 5
+  despawnOnCollisionTime: 0.1
+  stopAfterCollision: 1
+--- !u!54 &-2821315963435612542
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5341742223406746680}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 2
+  m_Constraints: 0
+  m_CollisionDetection: 2
+--- !u!135 &-3140707969141230617
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5341742223406746680}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &8087445199789049519
 GameObject:
   m_ObjectHideFlags: 0
@@ -154,12 +237,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8087445199789049519}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4713719514245437058}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &2623390232990987660
 MeshFilter:
@@ -180,11 +264,15 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 257
   m_RendererPriority: 0
   m_Materials:
@@ -218,9 +306,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8087445199789049519}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 1825911833616084214, guid: 845a646869bbb9449b4bb2c5973d6dc7, type: 3}

--- a/Assets/Sprites/UI/Symbols/Crosshair/blocked.svg.meta
+++ b/Assets/Sprites/UI/Symbols/Crosshair/blocked.svg.meta
@@ -44,6 +44,7 @@ ScriptedImporter:
       pivot: {x: 0, y: 0}
       alignment: 0
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       rect:
         serializedVersion: 2
         x: 0

--- a/Assets/Sprites/UI/Symbols/Crosshair/crosshair.svg.meta
+++ b/Assets/Sprites/UI/Symbols/Crosshair/crosshair.svg.meta
@@ -44,6 +44,7 @@ ScriptedImporter:
       pivot: {x: 0, y: 0}
       alignment: 0
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       rect:
         serializedVersion: 2
         x: 0

--- a/Assets/Sprites/UI/Symbols/Gun Condition/chamber.svg.meta
+++ b/Assets/Sprites/UI/Symbols/Gun Condition/chamber.svg.meta
@@ -44,6 +44,7 @@ ScriptedImporter:
       pivot: {x: 0, y: 0}
       alignment: 0
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       rect:
         serializedVersion: 2
         x: 0

--- a/Assets/Sprites/UI/Symbols/Gun Condition/charge.svg.meta
+++ b/Assets/Sprites/UI/Symbols/Gun Condition/charge.svg.meta
@@ -44,6 +44,7 @@ ScriptedImporter:
       pivot: {x: 0, y: 0}
       alignment: 0
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       rect:
         serializedVersion: 2
         x: 0

--- a/Assets/Sprites/UI/Symbols/armor.svg.meta
+++ b/Assets/Sprites/UI/Symbols/armor.svg.meta
@@ -44,6 +44,7 @@ ScriptedImporter:
       pivot: {x: 0, y: 0}
       alignment: 0
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       rect:
         serializedVersion: 2
         x: 0

--- a/Assets/Sprites/UI/Symbols/bar_empty.svg.meta
+++ b/Assets/Sprites/UI/Symbols/bar_empty.svg.meta
@@ -44,6 +44,7 @@ ScriptedImporter:
       pivot: {x: 0, y: 0}
       alignment: 0
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       rect:
         serializedVersion: 2
         x: 0

--- a/Assets/Sprites/UI/Symbols/bar_filled.svg.meta
+++ b/Assets/Sprites/UI/Symbols/bar_filled.svg.meta
@@ -44,6 +44,7 @@ ScriptedImporter:
       pivot: {x: 0, y: 0}
       alignment: 0
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       rect:
         serializedVersion: 2
         x: 0

--- a/Assets/Sprites/UI/Symbols/dashbar_empty.svg.meta
+++ b/Assets/Sprites/UI/Symbols/dashbar_empty.svg.meta
@@ -44,6 +44,7 @@ ScriptedImporter:
       pivot: {x: 0, y: 0}
       alignment: 0
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       rect:
         serializedVersion: 2
         x: 0

--- a/Assets/Sprites/UI/Symbols/dashbar_filled.svg.meta
+++ b/Assets/Sprites/UI/Symbols/dashbar_filled.svg.meta
@@ -44,6 +44,7 @@ ScriptedImporter:
       pivot: {x: 0, y: 0}
       alignment: 0
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       rect:
         serializedVersion: 2
         x: 0

--- a/Assets/Sprites/UI/Symbols/health.svg.meta
+++ b/Assets/Sprites/UI/Symbols/health.svg.meta
@@ -44,6 +44,7 @@ ScriptedImporter:
       pivot: {x: 0, y: 0}
       alignment: 0
       border: {x: 0, y: 0, z: 0, w: 0}
+      customData: 
       rect:
         serializedVersion: 2
         x: 0

--- a/Assets/_Scripts/Base/BaseBullet.cs
+++ b/Assets/_Scripts/Base/BaseBullet.cs
@@ -24,4 +24,7 @@ public class BaseBullet: MonoBehaviour {
     public void Destroy() {
         Destroy(gameObject);
     }
+    protected virtual void Start() {
+        SetupBullet();
+    }
 }

--- a/Assets/_Scripts/Base/BaseGun.cs
+++ b/Assets/_Scripts/Base/BaseGun.cs
@@ -44,7 +44,7 @@ public abstract class BaseGun : MonoBehaviour
 {
     [Header("General")]
     public string gunName;
-    public GameObject ammoType;
+    public GameObject ammoPrefab;
     public int ammoCapacity = 10;
     [Range (0.0f, 10.0f)]
     public float mass = 0.1f;
@@ -397,7 +397,7 @@ public abstract class BaseGun : MonoBehaviour
         shootingDirection.y += Random.Range(-spreadAtDistance, spreadAtDistance);
         
         // Instantiate the bullet
-        GameObject bullet = Instantiate(ammoType, firePoint.transform.position, transform.rotation);
+        GameObject bullet = Instantiate(ammoPrefab, firePoint.transform.position, transform.rotation);
         bullet.GetComponent<Rigidbody>().linearVelocity = shootingDirection * muzzleVelocity;
         bullet.GetComponent<BaseBullet>().source = gameObject;
 

--- a/Assets/_Scripts/Managers/UiManager.cs
+++ b/Assets/_Scripts/Managers/UiManager.cs
@@ -30,27 +30,21 @@ public class UiUpdater: MonoBehaviour {
                 switch (uiElementName) {
                     case "Ammo Count UI":
                         ammoCountUI = uiObject.GetComponent<TextMeshProUGUI>();
-                        Debug.Log("Ammo Count GameObject found!");
                         break;
                     case "Chamber UI":
                         chamberUI = uiObject.GetComponent<SVGImage>();
-                        Debug.Log("Chamber UI GameObject found!");
                         break;
                     case "Charge UI":
                         chargeUI = uiObject.GetComponent<SVGImage>();
-                        Debug.Log("Charge UI GameObject found!");
                         break;
                     case "Fire Mode UI":
                         fireModeUI = uiObject.GetComponent<TextMeshProUGUI>();
-                        Debug.Log("Fire Mode UI GameObject found!");
                         break;
                     case "Gun Name UI":
                         gunNameUI = uiObject.GetComponent<TextMeshProUGUI>();
-                        Debug.Log("Gun Name UI GameObject found!");
                         break;
                     case "Reloading UI":
                         ReloadingUI = uiObject.GetComponent<RawImage>();
-                        Debug.Log("Reloading UI GameObject found!");
                         break;
                 }
             } else {

--- a/Assets/_Scripts/Objects/Projectiles/Compressed Mangifera.cs
+++ b/Assets/_Scripts/Objects/Projectiles/Compressed Mangifera.cs
@@ -7,7 +7,7 @@ class CompressedMangifera: BaseBullet {
     public float explosionForce = 5f;
     public bool stopAfterCollision = true;
     private bool firstHit = true;
-    void Start() {
+    override protected void Start() {
         SetupBullet();
         Invoke("Destroy", despawnTime);
     }
@@ -29,7 +29,6 @@ class CompressedMangifera: BaseBullet {
                     hitCollider.GetComponent<Rigidbody>().AddExplosionForce(explosionForce, transform.position, explosionRadius);
                 }
             }
-            Debug.Log("Hit object: " + hitObject.name);
             Invoke("Destroy", despawnOnCollisionTime);  
             firstHit = false;
         }

--- a/Assets/_Scripts/Objects/Projectiles/Spit Ball.cs
+++ b/Assets/_Scripts/Objects/Projectiles/Spit Ball.cs
@@ -9,7 +9,7 @@ public class SpitBall : BaseBullet
     public bool stopAfterCollision = true;
     private bool firstHit = true;
     // Start is called before the first frame update
-    void Start()
+    override protected void Start()
     {
         SetupBullet();
         Invoke("Destroy", despawnTime);
@@ -30,7 +30,6 @@ public class SpitBall : BaseBullet
                 float damage = 10f;
                 hitObject.GetComponent<BaseEnemy>().TakeDamage(damage);
             }
-            Debug.Log("Hit object: " + hitObject.name);
             Invoke("Destroy", despawnOnCollisionTime);  
             firstHit = false;
         }


### PR DESCRIPTION
The current projectiles in the game are now facing several problems as follows:
- The BaseBullet class in itself can't work standalone: Dealing damage to enemies,  as well as hit count detection isn't implemented yet for the base class.
- The Update() and Start() function inherritance is REALLY bad
- Setting up bullets should also check for missing fundamental components: Rigidbody, MeshCollider and so on  
- (Requires further investigation) And I quote "Mesh that concave can't have Rigidbody" or something